### PR TITLE
Restructure event listener methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,16 @@
-# solana_event_listener
+# Solana Event Listener Overview
+This repo contains our solana event listener, which listens on and stores information from recent slots/blocks on the solana blockchain. Written in Rust.
+# How it works - src/main.rs
+- Our event listener gets the most recently finalized slot on the solana blockchain. It takes this slot number and attempts to retrieve the block present in that slot. If a block is unable to be retrieved, it will retry until a time-out. 
+- Upon successful retrieval, the block information and it's transactions will be parsed and stored in a data structure as well as printed to the console.
+- The information stored in the data structure, once gathered, will be sent to an AWS database for logging.
+# Libraries Used
+- solana-sdk: used to connect to solana rpc endpoint
+- solana-client: used for various solana methods, namely CommitmentConfig, which lets us specify a commitment level when trying to acquire the most recent slot.
+- tokio: used for asynchronous operations and timing/delays. 
+- chrono: used for date and time formatting
+## TODO
+- investigate and fix RPC response error -32015: Transaction version (0) is not supported by the requesting client. Please try the request again with the following configuration parameter: "maxSupportedTransactionVersion": 0
+- parse fields in retrieved blocks for desired information
+- Create data structure to hold the information from each slot/block to easily store in database
+- store in database in addition to printing to console

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,12 @@ This repo contains our solana event listener, which listens on and stores inform
 - solana-transaction-status: used for EncodedConfirmedBlock struct
 - tokio: used for asynchronous operations and timing/delays. 
 - chrono: used for date and time formatting
+## IMPORTANT TO NOTE
+- DEVNET HAS BEEN DOWN SINCE FEB 9th SO OUR EVENT LISTENER ONLY RETRIEVES THE MOST RECENT BLOCK REPEATEDLY. WILL REMOVE NOTICE ONCE DEVNET IS BACK UP
 ## TODO
 - investigate and fix RPC response error -32015: Transaction version (0) is not supported by the requesting client. Please try the request again with the following configuration parameter: "maxSupportedTransactionVersion": 0
+- in regards to above: use get_block_with_config and set the config's max supported transaction version to be 0.
+see https://docs.rs/solana-client/latest/solana_client/rpc_client/struct.RpcClient.html#method.get_block_with_config
+- ^^^THIS IS DONE, JUST NEED TO TEST ONCE DEVNET IS BACK ONLINE
 - parse fields in retrieved blocks for desired information
 - store in database in addition to printing to console

--- a/readme.md
+++ b/readme.md
@@ -2,15 +2,14 @@
 This repo contains our solana event listener, which listens on and stores information from recent slots/blocks on the solana blockchain. Written in Rust.
 # How it works - src/main.rs
 - Our event listener gets the most recently finalized slot on the solana blockchain. It takes this slot number and attempts to retrieve the block present in that slot. If a block is unable to be retrieved, it will retry until a time-out. 
-- Upon successful retrieval, the block information and it's transactions will be parsed and stored in a data structure as well as printed to the console.
-- The information stored in the data structure, once gathered, will be sent to an AWS database for logging.
+- Upon successful retrieval, the block information and it's transactions will be parsed and stored in an AWS database as well as printed to the console.
 # Libraries Used
 - solana-sdk: used to connect to solana rpc endpoint
 - solana-client: used for various solana methods, namely CommitmentConfig, which lets us specify a commitment level when trying to acquire the most recent slot.
+- solana-transaction-status: used for EncodedConfirmedBlock struct
 - tokio: used for asynchronous operations and timing/delays. 
 - chrono: used for date and time formatting
 ## TODO
 - investigate and fix RPC response error -32015: Transaction version (0) is not supported by the requesting client. Please try the request again with the following configuration parameter: "maxSupportedTransactionVersion": 0
 - parse fields in retrieved blocks for desired information
-- Create data structure to hold the information from each slot/block to easily store in database
 - store in database in addition to printing to console

--- a/solana_event_listener/Cargo.lock
+++ b/solana_event_listener/Cargo.lock
@@ -3790,6 +3790,7 @@ dependencies = [
  "chrono",
  "solana-client",
  "solana-sdk",
+ "solana-transaction-status",
  "tokio",
 ]
 

--- a/solana_event_listener/Cargo.lock
+++ b/solana_event_listener/Cargo.lock
@@ -3787,6 +3787,7 @@ dependencies = [
 name = "solana_event_listener"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "solana-client",
  "solana-sdk",
  "tokio",

--- a/solana_event_listener/Cargo.toml
+++ b/solana_event_listener/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2021"
 solana-sdk = "1.18.1"
 solana-client = "1.18.1"
 tokio = { version = "1", features = ["full"] }
+chrono = "0.4"
+

--- a/solana_event_listener/Cargo.toml
+++ b/solana_event_listener/Cargo.toml
@@ -10,4 +10,5 @@ solana-sdk = "1.18.1"
 solana-client = "1.18.1"
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
+solana-transaction-status = "1.18.1"
 

--- a/solana_event_listener/src/main.rs
+++ b/solana_event_listener/src/main.rs
@@ -1,24 +1,44 @@
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::commitment_config::CommitmentConfig;
+//use chrono::{DateTime, Utc, TimeZone};
 
-const MAX_ITER : i32 = 10; //number of blocks to get before terminating
+const MAX_ITER : i32 = 10; //number of slots to get and try to retrieve a block from before terminating
+const MAX_RETRIES : i32 = 5; //number of retries to retrieve block from the current slot before timing out
 
 async fn listen_to_blocks() {
-    let rpc_url = "https://api.testnet.solana.com".to_string(); // Using testnet for testing, tokens have no real-world value, no limitations. will likely swap to mainnet once tested and working.
+    let rpc_url = "https://api.devnet.solana.com".to_string(); // Using devnet for testing, will likely swap to mainnet once tested and working.
     let rpc_client = RpcClient::new(rpc_url); //connect to rpc endpoint
     let mut iter = 0;
 
     loop{
-        let recent_block = rpc_client.get_latest_blockhash_with_commitment(CommitmentConfig::confirmed()); //get most recent confirmed block
-        match recent_block {
-            Ok((blockhash, block_height)) => {
-                //print information to the console if values exist
-                println!("Block Height: {}", block_height);
-                println!("Blockhash: {:?}", blockhash);
+        let mut retries = 0;
+        let latest_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::finalized()); //get latest slot
+        match latest_slot{
+            Ok(slot) => {
+                println!("\nLatest Slot: {}", slot);
+
+                let latest_block = rpc_client.get_block(slot); //get block at latest slot
+                loop{
+                    match latest_block{
+                        Ok(_encoded_confirmed_block) =>{
+                            //println!("Latest Block: {:?}", encoded_confirmed_block);
+                            println!("Block at slot {} found and information retrieved",slot);
+                            break;
+                        }
+                        Err(ref err) =>{
+                            retries += 1;
+                            if retries >= MAX_RETRIES {
+                                eprintln!("MAX_RETRIES reached, timing out and moving to next slot");
+                                break;
+                            }
+                            eprintln!("Error getting latest block: {}", err);
+                            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                        }
+                    }
+                }
             }
             Err(err) => {
-                //handle error
-                eprintln!("Error getting recent block hash: {}", err);  
+                eprintln!("Error getting latest slot: {}", err);
             }
         }
 


### PR DESCRIPTION
changed data retrieval approach and mechanisms

get slot
moved from get_block to get_block_with_config
made functions to parse data

devnet was down when I made the config changes so those still need to be tested, currently only the most recent slot/block from FEB 9th is being retrieved. It was working before these changes so i can always revert if necessary. Will test and fix if needed once devnet is back online.